### PR TITLE
Fix force type casting crash

### DIFF
--- a/Sources/SecureDefaults/SecureDefaults.swift
+++ b/Sources/SecureDefaults/SecureDefaults.swift
@@ -260,8 +260,8 @@ public class SecureDefaults: UserDefaults {
     
     private func secretObject(forKey defaultName: String) -> Any? {
         let object = super.object(forKey: defaultName)
-        if let object = object {
-            guard let decrypted = try? decrypter?.decrypt(object as! Data) else { return nil }
+        if let object = object as? Data {
+            guard let decrypted = try? decrypter?.decrypt(object) else { return nil }
             let data = NSKeyedUnarchiver.unarchiveObject(with: decrypted)
             return data
         }


### PR DESCRIPTION
Fix force type casting crash

###  Summary

Reading from SecureDefaults resolved crash by optional type casting to Data type

### Requirements

* [x] I've read and agree to the [Code of Conduct](CODE_OF_CONDUCT.md).
* [x] I've written tests to cover the new code and functionality included in this PR.